### PR TITLE
bug fixed

### DIFF
--- a/mag1c/mag1c.py
+++ b/mag1c/mag1c.py
@@ -786,7 +786,7 @@ def main():
     if args.out is not None:
         output_filename = f'{args.out}.hdr'
     else:
-        output_filename = os.path.basename(args.rdn)[:len('xxxYYYYMMDDtHHMMSS')] + '_ch4_cmfr'
+        output_filename = os.path.basename(args.rdn)[:len('xxxYYYYMMDDtHHMMSS')] + '_ch4_cmfr' + '.hdr'
     output_file = spectral.io.envi.create_image(output_filename, output_metadata, force=args.overwrite, ext='')
     output_memmap = output_file.open_memmap(interleave='bip', writable=True)
     qprint(f'Filter output will be written to {output_filename}')


### PR DESCRIPTION
Running mag1c using only input radiance filename arg. (while output name arg. is not defined) e.g.:

`mag1c INPUT_RADIANCE`

Causes the following error:

> Traceback (most recent call last):
  File "c:\users\ali radman\appdata\local\programs\python\python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\users\ali radman\appdata\local\programs\python\python37\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\Ali Radman\AppData\Local\Programs\Python\Python37\Scripts\mag1c.exe\__main__.py", line 7, in <module>
  File "c:\users\ali radman\appdata\local\programs\python\python37\lib\site-packages\mag1c\mag1c.py", line 790, in main
    output_file = spectral.io.envi.create_image(output_filename, output_metadata, force=args.overwrite, ext='')
  File "c:\users\ali radman\appdata\local\programs\python\python37\lib\site-packages\spectral\io\envi.py", line 784, in create_image
    (hdr_file, img_file) = check_new_filename(hdr_file, img_ext, force)
  File "c:\users\ali radman\appdata\local\programs\python\python37\lib\site-packages\spectral\io\envi.py", line 371, in check_new_filename
    raise EnviException('Header file name must end in ".hdr" or ".HDR".')
spectral.io.envi.EnviException: Header file name must end in ".hdr" or ".HDR".

The applied modification to your master branch solves this issue.

