### PR TITLE
Properly handle when a mask isn't provided

### DIFF
--- a/mag1c/mag1c.py
+++ b/mag1c/mag1c.py
@@ -99,7 +99,7 @@ def acrwl1mf(x: torch.Tensor,
     device = x.device
     N = x.shape[1]  # number of samples
     if mask is None:
-        mask = torch.ones(x.shape[:-1], dtype=torch.bool)
+        mask = torch.ones(x.shape[:-1], dtype=torch.bool, device=x.device)
     mask = torch.squeeze(mask, 0)
     regularizer = torch.zeros(x.shape[0], x.shape[1], 1, dtype=dtype, device=device)
     modx = x[:, mask]#torch.zeros_like(x, dtype=dtype, device=device, layout=torch.strided)

--- a/mag1c/mag1c.py
+++ b/mag1c/mag1c.py
@@ -99,7 +99,7 @@ def acrwl1mf(x: torch.Tensor,
     device = x.device
     N = x.shape[1]  # number of samples
     if mask is None:
-        mask = torch.ones_like(x, dtype=torch.bool)
+        mask = torch.ones(x.shape[:-1], dtype=torch.bool)
     mask = torch.squeeze(mask, 0)
     regularizer = torch.zeros(x.shape[0], x.shape[1], 1, dtype=dtype, device=device)
     modx = x[:, mask]#torch.zeros_like(x, dtype=dtype, device=device, layout=torch.strided)


### PR DESCRIPTION
An error occurs on this line when `mask is None`:
https://github.com/markusfoote/mag1c/blob/8b9ceae186f4e125bc9f628db82f41bce4c6011f/mag1c/mag1c.py#L117

To fix it, we repurpose how the working parts of the code generate an empty mask:
https://github.com/markusfoote/mag1c/blob/8b9ceae186f4e125bc9f628db82f41bce4c6011f/mag1c/mag1c.py#L836 https://github.com/markusfoote/mag1c/blob/8b9ceae186f4e125bc9f628db82f41bce4c6011f/mag1c/mag1c.py#L854